### PR TITLE
#32 adds libsodium 26 to supported versions

### DIFF
--- a/libsodium/sodium.nim
+++ b/libsodium/sodium.nim
@@ -17,7 +17,7 @@ when defined(windows):
 elif defined(macosx):
   const libsodium_fn* = "libsodium.dylib"
 else:
-  const libsodium_fn* = "libsodium.so(.18|.23)"
+  const libsodium_fn* = "libsodium.so(.18|.23|.26)"
 
 
 {.pragma: sodium_import, importc, dynlib: libsodium_fn.}

--- a/libsodium/sodium_sizes.nim
+++ b/libsodium/sodium_sizes.nim
@@ -10,7 +10,7 @@ when defined(windows):
 elif defined(macosx):
   const libsodium_fn* = "libsodium.dylib"
 else:
-  const libsodium_fn* = "libsodium.so(.18|.23)"
+  const libsodium_fn* = "libsodium.so(.18|.23|.26)"
 
 {.pragma: sodium_import, importc, dynlib: libsodium_fn.}
 


### PR DESCRIPTION
Arch Linux already has said version and it runs the test-suite just fine. So no major breaking changes.

closes #32